### PR TITLE
Use gmtime.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,10 @@ let package = Package(
         .testTarget(
             name: "DateTimeTests",
             dependencies: ["DateTime"]
+        ),
+        .testTarget(
+            name: "EpochDateTimeTests",
+            dependencies: ["DateTime"]
         )
     ]
 )

--- a/Sources/DateTime/EpochDateTime.swift
+++ b/Sources/DateTime/EpochDateTime.swift
@@ -15,8 +15,8 @@
 private let secondsPerHour = 60 * 60
 private let secondsPerDay = 24 * 60 * 60
 private let secondsPerMinute = 60
-private let secondsPerNormalYear = 366 * secondsPerDay // These are correct
-private let secondsPerLeapYear = 365 * secondsPerDay
+private let secondsPerNormalYear = 365 * secondsPerDay
+private let secondsPerLeapYear = 366 * secondsPerDay
 
 private let monthsNormal = [-9_999,
                             31 * secondsPerDay,
@@ -80,16 +80,16 @@ public struct EpochDateTime {
         while remainingTime > 0 {
             let isLeap = isLeapYear(year)
 
-            if isLeap, remainingTime >= secondsPerLeapYear { // this is correct
-                remainingTime -= secondsPerNormalYear
-                year += 1
-            } else if remainingTime >= secondsPerNormalYear { // this is correct
+            if isLeap, remainingTime >= secondsPerLeapYear {
                 remainingTime -= secondsPerLeapYear
+                year += 1
+            } else if !isLeap, remainingTime >= secondsPerNormalYear {
+                remainingTime -= secondsPerNormalYear
                 year += 1
             } else if isLeap, remainingTime >= monthsLeap[month] {
                 remainingTime -= monthsLeap[month]
                 month += 1
-            } else if remainingTime >= monthsNormal[month] {
+            } else if !isLeap, remainingTime >= monthsNormal[month] {
                 remainingTime -= monthsNormal[month]
                 month += 1
             } else if remainingTime >= secondsPerDay {

--- a/Sources/DateTime/EpochDateTime.swift
+++ b/Sources/DateTime/EpochDateTime.swift
@@ -12,39 +12,7 @@
 
 // Adopted from C implementation at https://www.quora.com/How-do-I-convert-epoch-time-to-a-date-manually
 
-private let secondsPerHour = 60 * 60
-private let secondsPerDay = 24 * 60 * 60
-private let secondsPerMinute = 60
-private let secondsPerNormalYear = 365 * secondsPerDay
-private let secondsPerLeapYear = 366 * secondsPerDay
-
-private let monthsNormal = [-9_999,
-                            31 * secondsPerDay,
-                            28 * secondsPerDay,
-                            31 * secondsPerDay,
-                            30 * secondsPerDay,
-                            31 * secondsPerDay,
-                            30 * secondsPerDay,
-                            31 * secondsPerDay,
-                            31 * secondsPerDay,
-                            30 * secondsPerDay,
-                            31 * secondsPerDay,
-                            30 * secondsPerDay,
-                            31 * secondsPerDay]
-
-private let monthsLeap = [-9_999,
-                          31 * secondsPerDay,
-                          29 * secondsPerDay,
-                          31 * secondsPerDay,
-                          30 * secondsPerDay,
-                          31 * secondsPerDay,
-                          30 * secondsPerDay,
-                          31 * secondsPerDay,
-                          31 * secondsPerDay,
-                          30 * secondsPerDay,
-                          31 * secondsPerDay,
-                          30 * secondsPerDay,
-                          31 * secondsPerDay]
+import Darwin
 
 public struct EpochDateTime {
     public var year: Int
@@ -62,49 +30,16 @@ public struct EpochDateTime {
         Self(year: 2_022, month: 5, day: 20, hour: 14, minute: 0, second: 0)
     }
 
-    internal func isLeapYear(_ year: Int) -> Bool {
-        if (year % 4) != 0 {
-            return false
-        } else if (year % 100) != 0 {
-            return true
-        } else if (year % 400) != 0 {
-            return false
-        }
-        return true
-    }
-
     /// Converts a timestamp in seconds to the appropriate year/month/day/hour/minute/second from the Unix epoch
     public mutating func convert(timestamp: Int) {
-        var remainingTime = timestamp
-
-        while remainingTime > 0 {
-            let isLeap = isLeapYear(year)
-
-            if isLeap, remainingTime >= secondsPerLeapYear {
-                remainingTime -= secondsPerLeapYear
-                year += 1
-            } else if !isLeap, remainingTime >= secondsPerNormalYear {
-                remainingTime -= secondsPerNormalYear
-                year += 1
-            } else if isLeap, remainingTime >= monthsLeap[month] {
-                remainingTime -= monthsLeap[month]
-                month += 1
-            } else if !isLeap, remainingTime >= monthsNormal[month] {
-                remainingTime -= monthsNormal[month]
-                month += 1
-            } else if remainingTime >= secondsPerDay {
-                remainingTime -= secondsPerDay
-                day += 1
-            } else if remainingTime >= secondsPerHour {
-                remainingTime -= secondsPerHour
-                hour += 1
-            } else if remainingTime >= secondsPerMinute {
-                remainingTime -= secondsPerMinute
-                minute += 1
-            } else {
-                second = remainingTime
-                remainingTime = 0
-            }
-        }
+        var timestamp = timestamp
+        var tm = tm()
+        gmtime_r(&timestamp, &tm)
+        year = Int(tm.tm_year + 1900)
+        month = Int(tm.tm_mon + 1)
+        day = Int(tm.tm_mday)
+        hour = Int(tm.tm_hour)
+        minute = Int(tm.tm_min)
+        second = Int(tm.tm_sec)
     }
 }

--- a/Sources/DateTime/EpochDateTime.swift
+++ b/Sources/DateTime/EpochDateTime.swift
@@ -12,7 +12,13 @@
 
 // Adopted from C implementation at https://www.quora.com/How-do-I-convert-epoch-time-to-a-date-manually
 
+#if canImport(Darwin)
 import Darwin
+#endif
+
+#if canImport(Glibc)
+import Glibc
+#endif
 
 public struct EpochDateTime {
     public var year: Int

--- a/Tests/EpochDateTimeTests/EpochDateTimeTests.swift
+++ b/Tests/EpochDateTimeTests/EpochDateTimeTests.swift
@@ -1,0 +1,120 @@
+// Copyright 2023 Ordo One AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+
+@testable import DateTime
+import XCTest
+
+private let secondsPerHour = 60 * 60
+private let secondsPerDay = 24 * 60 * 60
+private let secondsPerMinute = 60
+private let secondsPerNormalYear = 365 * secondsPerDay
+private let secondsPerLeapYear = 366 * secondsPerDay
+
+private let monthsNormal = [-9_999,
+                            31 * secondsPerDay,
+                            28 * secondsPerDay,
+                            31 * secondsPerDay,
+                            30 * secondsPerDay,
+                            31 * secondsPerDay,
+                            30 * secondsPerDay,
+                            31 * secondsPerDay,
+                            31 * secondsPerDay,
+                            30 * secondsPerDay,
+                            31 * secondsPerDay,
+                            30 * secondsPerDay,
+                            31 * secondsPerDay]
+
+private let monthsLeap = [-9_999,
+                          31 * secondsPerDay,
+                          29 * secondsPerDay,
+                          31 * secondsPerDay,
+                          30 * secondsPerDay,
+                          31 * secondsPerDay,
+                          30 * secondsPerDay,
+                          31 * secondsPerDay,
+                          31 * secondsPerDay,
+                          30 * secondsPerDay,
+                          31 * secondsPerDay,
+                          30 * secondsPerDay,
+                          31 * secondsPerDay]
+
+extension EpochDateTime {
+    private func isLeapYear(_ year: Int) -> Bool {
+        if (year % 4) != 0 {
+            return false
+        } else if (year % 100) != 0 {
+            return true
+        } else if (year % 400) != 0 {
+            return false
+        }
+        return true
+    }
+
+    mutating func convertOld(timestamp: Int) {
+        var remainingTime = timestamp
+
+        while remainingTime > 0 {
+            let isLeap = isLeapYear(year)
+
+            if isLeap, remainingTime >= secondsPerLeapYear {
+                remainingTime -= secondsPerLeapYear
+                year += 1
+            } else if !isLeap, remainingTime >= secondsPerNormalYear {
+                remainingTime -= secondsPerNormalYear
+                year += 1
+            } else if isLeap, remainingTime >= monthsLeap[month] {
+                remainingTime -= monthsLeap[month]
+                month += 1
+            } else if !isLeap, remainingTime >= monthsNormal[month] {
+                remainingTime -= monthsNormal[month]
+                month += 1
+            } else if remainingTime >= secondsPerDay {
+                remainingTime -= secondsPerDay
+                day += 1
+            } else if remainingTime >= secondsPerHour {
+                remainingTime -= secondsPerHour
+                hour += 1
+            } else if remainingTime >= secondsPerMinute {
+                remainingTime -= secondsPerMinute
+                minute += 1
+            } else {
+                second = remainingTime
+                remainingTime = 0
+            }
+        }
+    }
+}
+
+final class EpochDateTimeTests: XCTestCase {
+
+    func testPerf() throws {
+        let clock = ContinuousClock()
+        var vv: Int = 0
+
+        let oldImplWorkTime = clock.measure {
+            for time in 1672531200..<(1672531200+1_000_000) {
+                var epoch = EpochDateTime.unixEpoch()
+                epoch.convertOld(timestamp: time)
+                vv += epoch.year
+            }
+        }
+
+        print("Old implementation: vv=\(vv), elapsed time=\(oldImplWorkTime)")
+
+        vv = 0
+        let newImplWorkTime = clock.measure {
+            for time in 1672531200..<(1672531200+1_000_000) {
+                var epoch = EpochDateTime.unixEpoch()
+                epoch.convert(timestamp: time)
+                vv += epoch.year
+            }
+        }
+
+        print("New implementation: vv=\(vv), elapsed time=\(newImplWorkTime)")
+    }
+}


### PR DESCRIPTION
## Description

Own implementation for EpochDateTime did not worked properly for all dates.
Probably better to use gmtime() function from the standard library, at least it is well tested.

## How Has This Been Tested?

Unit tests.

## Minimal checklist:

- [X] I have performed a self-review of my own code 
- [ ] I have added `DocC` code-level documentation for any public interfaces exported by the package
- [ ] I have added unit and/or integration tests that prove my fix is effective or that my feature works
